### PR TITLE
Component routes

### DIFF
--- a/sample/src/project-status/controls.css
+++ b/sample/src/project-status/controls.css
@@ -1,0 +1,11 @@
+.control-info.wip {
+  background: url('images/orange.png') left center no-repeat;
+}
+
+.control-info.done {
+  background: url('images/blue.png') left center no-repeat;
+}
+
+.control-info {
+  padding-left: 15px;
+}

--- a/sample/src/project-status/controls.html
+++ b/sample/src/project-status/controls.html
@@ -1,4 +1,5 @@
 <template>
+  <require from="./controls.css"></require>
    <div class="col-md-12">
      <h2>Project status</h2>
      <section>
@@ -19,38 +20,22 @@
                            controls in development
                        </span>
                    </p>
-                   <br>
-                   <br>
                </div>
            </div>
 
           <div class="row">
-               <div class="col-xs-12 col-sm-2">
-                   <img src="images/blue.png">
-                   <a href="#/samples/click-counter">Click counter</a>       <br>
-                   
-                   <img src="images/orange.png">
-                   <a href="#/samples/navbar">Navbar</a>       <br>
-                   
-                   <img src="images/orange.png">
-                   <a href="#/samples/navs">Tabs/Pills</a>       <br>
-                   
-                   <img src="images/orange.png">
-                   <a href="#/samples/panel">Panel</a>       <br>
-                   
-                   <img src="images/orange.png">
-                   <a href="#/samples/button">Button</a>       <br>
-                   
-                   <img src="images/orange.png">
-                   <a href="#/samples/collapse">Collapse</a>       <br>
-                   
-               </div>
-           <br>
-           <br>
-           <br>
-           <br>
-
-           <h4>Check <a href="http://aurelia-ui-toolkits.github.io/demo-kendo/#/project-status">this page</a> for the the example of what could be the content of this page<h4>
+               <b-panel class="col-xs-12 col-sm-3" repeat.for="category of categories">
+                 <b-panel-header>${category.title}</b-panel-header>
+                 <b-panel-body>
+                   <div repeat.for="ctrl of category.controls" class="control-info ${ ctrl.status }">
+                      <a if.bind="ctrl.link" href="${ ctrl.link }">${ ctrl.title }</a>
+                      <span if.bind="!ctrl.link">${ ctrl.title }</span>
+                    </div>
+                 </b-panel-body>
+               </b-panel>
+       </div>
+       <div class="row">
+         <h4>Check <a href="http://aurelia-ui-toolkits.github.io/demo-kendo/#/project-status">this page</a> for the the example of what could be the content of this page<h4>
        </div>
 
     </section>

--- a/sample/src/project-status/controls.js
+++ b/sample/src/project-status/controls.js
@@ -1,1 +1,9 @@
-export class Controls {}
+import { inject } from 'aurelia-dependency-injection';
+import { ComponentService } from '../shared/component-service';
+
+@inject(ComponentService)
+export class Controls {
+  constructor(componentService) {
+    this.categories = componentService.getIterableComponents();
+  }
+}

--- a/sample/src/samples/index.js
+++ b/sample/src/samples/index.js
@@ -1,25 +1,29 @@
 import {inject} from 'aurelia-framework';
 import {Registry} from 'shared/registry';
+import { ComponentService } from '../shared/component-service';
 
-@inject(Registry)
+@inject(Registry, ComponentService)
 export class Index {
 
-  constructor(registry) {
+  constructor(registry, componentService) {
     this.registry = registry;
+    this.componentService = componentService;
+    this.routerConfig = componentService.getRouterConfig(true);
   }
   configureRouter(config, router) {
     config.title = 'Samples';
 
-    config.map([
-      { name: 'default', route: '', redirect: 'click-counter' },
-      { name: 'click-counter', route: 'click-counter', moduleId: './click-counter/index', title: 'Click-counter' },
-      { name: 'navbar', route: 'navbar', moduleId: './navbar/index', title: 'Navbar' },
-      { name: 'navs', route: 'navs', moduleId: './navs/index', title: 'Navs' },
-      { name: 'button', route: 'button', moduleId: './button/index', title: 'Button' },
-      { name: 'collapse', route: 'collapse', moduleId: './collapse/index', title: 'Collapse' },
-      { name: 'panel', route: 'panel', moduleId: './panel/index', title: 'Panel' }
-    ]);
-
+    // config.map([
+    //   { name: 'default', route: '', redirect: 'click-counter' },
+    //   { name: 'click-counter', route: 'click-counter', moduleId: './click-counter/index', title: 'Click-counter' },
+    //   { name: 'navbar', route: 'navbar', moduleId: './navbar/index', title: 'Navbar' },
+    //   { name: 'navs', route: 'navs', moduleId: './navs/index', title: 'Navs' },
+    //   { name: 'button', route: 'button', moduleId: './button/index', title: 'Button' },
+    //   { name: 'collapse', route: 'collapse', moduleId: './collapse/index', title: 'Collapse' },
+    //   { name: 'panel', route: 'panel', moduleId: './panel/index', title: 'Panel' }
+    // ]);
+    this.routerConfig.unshift({ name: 'default', route: '', redirect: 'click-counter' });
+    config.map(this.routerConfig);
     this.router = router;
   }
 }

--- a/sample/src/samples/menu.html
+++ b/sample/src/samples/menu.html
@@ -1,2 +1,14 @@
 <template>
+  <div class="btn-group" role="group">
+    <div repeat.for="category of categories" class="btn-group">
+      <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        ${category.title}<span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <li repeat.for="ctrl of category.controls">
+          <a href.bind="ctrl.link">${ ctrl.title }</a>
+        </li>
+      </ul>
+    </div>
+  </div>
 </template>

--- a/sample/src/samples/menu.js
+++ b/sample/src/samples/menu.js
@@ -1,18 +1,21 @@
 import {inject, bindable} from 'aurelia-framework';
 import {DOM} from 'aurelia-pal';
+import { ComponentService } from '../shared/component-service';
 import json from './menu.json!';
 
-@inject(Element)
+@inject(Element, ComponentService)
 export class Menu {
 
   @bindable router;
 
-  constructor(element) {
+  constructor(element, componentService) {
+    this.categories = componentService.getIterableComponents(true);
     this.element = element;
+    this.componentService = componentService;
   }
 
   attached() {
-    this.generateRow(json);
+    // this.generateRow(json);
   }
 
   generateRow(data) {

--- a/sample/src/shared/component-service.js
+++ b/sample/src/shared/component-service.js
@@ -1,0 +1,49 @@
+import * as components from './components.json!json';
+
+export class ComponentService {
+  constructor() {
+    this.components = components;
+  }
+
+  getIterableComponents(hideEmptyCategories = false) {
+    let categories = [];
+    for (let cat of Object.keys(this.components)) {
+      if (cat !== 'default') {
+        let category = {
+          title: cat,
+          controls: []
+        };
+        let cfg = this.components[cat];
+        for (let title of Object.keys(cfg)) {
+          let ctrl = {
+            title,
+            status: cfg[title].status
+          };
+          if (cfg[title].status && cfg[title].nav !== false) {
+            ctrl.link = `#/samples/${cfg[title].moduleId || title.toLowerCase()}`;
+          }
+          category.controls.push(ctrl);
+        }
+        if (!hideEmptyCategories || category.controls.some(c => !!c.link)) {
+          categories.push(category);
+        }
+      }
+    }
+    return categories;
+  }
+
+  getRouterConfig() {
+    let routes = [];
+    for (let cat of Object.keys(this.components)) {
+      let cfg = this.components[cat];
+      for (let title of Object.keys(cfg)) {
+        if (cfg[title].status && cfg[title].nav !== false) {
+          let shortModuleId = cfg[title].moduleId || title.toLowerCase();
+          let moduleId = `samples/${shortModuleId}/index`;
+          routes.push({ name: shortModuleId, route: shortModuleId, moduleId, title });
+        }
+      }
+    }
+    return routes;
+  }
+}

--- a/sample/src/shared/components.json
+++ b/sample/src/shared/components.json
@@ -1,0 +1,18 @@
+{
+  "Most popular": {
+    "Click counter": { "status": "done", "moduleId": "click-counter" }
+  },
+  "Navigation": {
+    "Navbar": { "status": "wip" },
+    "Navs": { "status": "wip" }
+  },
+   "Input": {
+    "Button": { "status": "wip" }
+  },
+   "Collapse": {
+    "Collapse": { "status": "wip" }
+  },
+   "Panel": {
+    "Panel": { "status": "wip" }
+  }
+}


### PR DESCRIPTION
Generating sample's routes, menu structure and project status from a single source.
I will only merge this myself when it's considered sufficiently general for this bridge. So please give some feedback. :smile: 

I could also try and style the project status to make it look nicer. Right now it's made of unstyled bootstrap panels (`b-panel`).
